### PR TITLE
Fixed issue with category filter

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -23,12 +23,12 @@ const Header = ({ user, profile }: HeaderType) => {
     <header>
       <div className="flex items-center bg-black p-4 lg:p-0">
         <div className="flex-1 lg:flex-grow lg:pl-4">
-          <Link to="/" prefetch="intent">
+          <a href="/" title="ToneHunt">
             <h1 className="text-3xl absolute hidden" style={{ left: "110%", top: "110%" }}>
               ToneHunt
             </h1>
             <Logo className="w-36 lg:w-44" />
-          </Link>
+          </a>
         </div>
 
         <div className="hidden lg:block flex-grow">


### PR DESCRIPTION
Clicking the logo (which was a Link component to index) while being in the List Model page (which is index) was not resetting the category filter. Changing the logo from Link to <a> fixed that issue.